### PR TITLE
Refactor the number of required nodes

### DIFF
--- a/docs/get-started/set-up-ibft-locally.md
+++ b/docs/get-started/set-up-ibft-locally.md
@@ -78,9 +78,11 @@ In this guide, we will treat the first and second nodes as the bootnodes for all
 is that nodes that connect to the `node 1` or `node 2` will get information on how to connect to one another through the mutually
 contacted bootnode. 
 
-:::info You need to specify at least two bootnodes to start a node
+:::info You need to specify at least one bootnode to start a node
 
-Having more bootnodes specified when setting up the network will give your nodes more resilience if one of the bootnodes becomes unresponsive, as there will be others to fall back to. It is up to you to decide if you want to list all 4 nodes as the bootnodes, or just two. In this guide we will list two nodes, but this can be changed on the fly, with no impact on the validity of the `genesis.json` file.
+At least **one** bootnode is required, so other nodes in the network can discover each other. More bootnodes are recommended, as
+they provide resilience to the network in case of outages.
+In this guide we will list two nodes, but this can be changed on the fly, with no impact on the validity of the `genesis.json` file.
 :::
 
 Since we are running on localhost, it is safe to assume that the `<ip_address>` is `127.0.0.1`.

--- a/docs/get-started/set-up-ibft-locally.md
+++ b/docs/get-started/set-up-ibft-locally.md
@@ -36,6 +36,16 @@ To achieve that, we will guide you through 4 easy steps:
 As all four nodes will be running on localhost, during the setup process it is expected that all the data directories
 for each of the nodes are in the same parent directory.
 
+:::info Number of validators
+
+There is no minimum to the number of nodes in a cluster, which means clusters with only 1 validator node are possible.
+Keep in mind that with a _single_ node cluster, there is **no crash tolerance** and **no BFT guarantee**.
+
+The minimum recommended number of nodes for achieving a BFT guarantee is 4 - since in a 4 node cluster, the failure of
+1 node can be tolerated, with the remaining 3 functioning normally.
+
+:::
+
 ## Step 1: Initialize data folders for IBFT and generate validator keys
 
 In order to get up and running with IBFT, you need to initialize the data folders,

--- a/docs/get-started/set-up-ibft-on-the-cloud.md
+++ b/docs/get-started/set-up-ibft-on-the-cloud.md
@@ -39,6 +39,16 @@ To achieve that, we will guide you through 4 easy steps:
 3. Create the `genesis.json` on your local machine, and send/transfer it to each of the nodes
 4. Start all the nodes 
 
+:::info Number of validators
+
+There is no minimum to the number of nodes in a cluster, which means clusters with only 1 validator node are possible.
+Keep in mind that with a _single_ node cluster, there is **no crash tolerance** and **no BFT guarantee**.
+
+The minimum recommended number of nodes for achieving a BFT guarantee is 4 - since in a 4 node cluster, the failure of
+1 node can be tolerated, with the remaining 3 functioning normally.
+
+:::
+
 ## Step 1: Initialize data folders and generate validator keys
 
 To get up and running with Polygon-SDK, you need to initialize the data folders, on each node:

--- a/docs/get-started/set-up-ibft-on-the-cloud.md
+++ b/docs/get-started/set-up-ibft-on-the-cloud.md
@@ -87,9 +87,11 @@ In this guide, we will treat the first and second nodes as the bootnodes for all
 is that nodes that connect to the `node 1` or `node 2` will get information on how to connect to one another through the mutually
 contacted bootnode. 
 
-:::info You need to specify at least two bootnodes to start a node
+:::info You need to specify at least one bootnode to start a node
 
-Having more bootnodes specified when setting up the network will give your nodes more resilience if one of the bootnodes becomes unresponsive, as there will be others to fall back to. It is up to you to decide if you want to list all 4 nodes as the bootnodes, or just two. In this guide, we will list two nodes, but this can be changed on the fly, with no impact on the validity of the `genesis.json` file.
+At least **one** bootnode is required, so other nodes in the network can discover each other. More bootnodes are recommended, as 
+they provide resilience to the network in case of outages.
+In this guide we will list two nodes, but this can be changed on the fly, with no impact on the validity of the `genesis.json` file.
 :::
 
 As the first part of the multiaddr connection string is the `<ip_address>`, here you will need to enter the IP address as reachable by other nodes, depending on your setup this might be a private or a public IP address, not `127.0.0.1`.


### PR DESCRIPTION
# Description

This PR refactors the documentation to note that at least `1` bootnode is required.

Reference PR: https://github.com/0xPolygon/polygon-edge/pull/351