### PR TITLE
[Hotfix] Remove description about --locals and --no-locals

### DIFF
--- a/docs/get-started/cli-commands.mdx
+++ b/docs/get-started/cli-commands.mdx
@@ -275,48 +275,6 @@ Sets the host DNS address. This can be used to advertise an external DNS. Suppor
 ---
 
 <h4>
-  <i>locals</i>
-</h4>
-
-<Tabs>
-  <TabItem value="syntax" label="Syntax" default>
-
-    server [--locals LOCALS]
-
-  </TabItem>
-  <TabItem value="example" label="Example">
-
-    server --locals 0xC12bB5d97A35c6919aC77C709d55F6aa60436900 
-
-  </TabItem>
-</Tabs>
-
-Sets comma-separated accounts whose transactions are treated as locals
-
----
-
-<h4>
-  <i>nolocals</i>
-</h4>
-
-<Tabs>
-  <TabItem value="syntax" label="Syntax" default>
-
-    server [--nolocals]
-
-  </TabItem>
-  <TabItem value="example" label="Example">
-
-    server --nolocals 
-
-  </TabItem>
-</Tabs>
-
-Sets flag to disable price exemptions for locally submitted transactions
-
----
-
-<h4>
   <i>price-limit</i>
 </h4>
 
@@ -569,48 +527,6 @@ Sets the gas limit of each block. Default: `5000`.
 </Tabs>
 
 Sets the ID of the chain. Default: `100`.
-
----
-
-<h4>
-  <i>locals</i>
-</h4>
-
-<Tabs>
-  <TabItem value="syntax" label="Syntax" default>
-
-    dev [--locals LOCALS]
-
-  </TabItem>
-  <TabItem value="example" label="Example">
-
-    dev --locals 0xC12bB5d97A35c6919aC77C709d55F6aa60436900 
-
-  </TabItem>
-</Tabs>
-
-Sets comma separated accounts whose transactions are treated as locals
-
----
-
-<h4>
-  <i>nolocals</i>
-</h4>
-
-<Tabs>
-  <TabItem value="syntax" label="Syntax" default>
-
-    dev [--nolocals]
-
-  </TabItem>
-  <TabItem value="example" label="Example">
-
-    dev --nolocals 
-
-  </TabItem>
-</Tabs>
-
-Sets flag to disable price exemptions for locally submitted transactions
 
 ---
 


### PR DESCRIPTION
This PR removes description about `--locals` and `--no-locals` flag in `server` and `dev` commands, which have been removed by TxPool refactoring.