### PR TITLE
Added block production time server flag

### DIFF
--- a/docs/get-started/cli-commands.mdx
+++ b/docs/get-started/cli-commands.mdx
@@ -431,6 +431,25 @@ Restore blocks from the specified archive file
 
 ---
 
+<h4><i>block-time</i></h4>
+
+<Tabs>
+  <TabItem value="syntax" label="Syntax" default>
+
+    server [--block-time BLOCK_TIME]
+
+  </TabItem>
+  <TabItem value="example" label="Example">
+
+    server --block-time 1
+
+  </TabItem>
+</Tabs>
+
+Set block production time in seconds. Default: `2`
+
+---
+
 ### dev flags
 
 <h4><i>log-level</i></h4>


### PR DESCRIPTION
This PR adds ```--block-time``` flag description to reflect changes introduced in PR [#382](https://github.com/0xPolygon/polygon-edge/pull/382)