### PR TITLE
Fix time from milliseconds to seconds

### DIFF
--- a/docs/configuration/enable-metrics.mdx
+++ b/docs/configuration/enable-metrics.mdx
@@ -20,5 +20,5 @@ The following metrics are available:
 | consensus_validators            | Gauge         | Number of Validators                            |
 | consensus_rounds                | Gauge         | Number of Rounds                                |
 | consensus_num_txs               | Gauge         | Number of Transactions in the latest block      |
-| consensus_block_interval        | Gauge         | Time between this and last block in miliseconds |
+| consensus_block_interval        | Gauge         | Time between this and last block in seconds     |
 | network_peers                   | Gauge         | Number of Connected peers                       |

--- a/docs/get-started/cli-commands.mdx
+++ b/docs/get-started/cli-commands.mdx
@@ -490,7 +490,7 @@ Restore blocks from the specified archive file
   </TabItem>
 </Tabs>
 
-Set block production time in miliseconds. Default: `2000`
+Set block production time in seconds. Default: `2`
 
 ---
 


### PR DESCRIPTION
# Description

This PR fixes a typo in the block timestamp from `milliseconds` to `seconds`