### PR TITLE
Use the right grpc flag in commands

### DIFF
--- a/docs/consensus/poa.md
+++ b/docs/consensus/poa.md
@@ -45,7 +45,7 @@ The structure of the IBFT commands is covered in the [CLI Commands](/docs/get-st
 Because in this example we are attempting to run the network where all nodes are on the same machine, we need to take care to avoid port conflicts. 
 
 ````bash
-polygon-edge server --data-dir ./test-chain-5 --chain genesis.json --grpc :50000 --libp2p :50001 --jsonrpc :50002 --seal
+polygon-edge server --data-dir ./test-chain-5 --chain genesis.json --grpc-address :50000 --libp2p :50001 --jsonrpc :50002 --seal
 ````
 
 After fetching all blocks, inside your console you will notice that a new node is participating in the validation

--- a/docs/get-started/set-up-ibft-locally.md
+++ b/docs/get-started/set-up-ibft-locally.md
@@ -286,25 +286,25 @@ avoid port conflicts. This is why we will use the following reasoning for determ
 To run the **first** client (note the port `10001` since it was used as a part of the libp2p multiaddr in **step 2** alongside node 1's Node ID):
 
 ````bash
-polygon-edge server --data-dir ./test-chain-1 --chain genesis.json --grpc :10000 --libp2p :10001 --jsonrpc :10002 --seal
+polygon-edge server --data-dir ./test-chain-1 --chain genesis.json --grpc-address :10000 --libp2p :10001 --jsonrpc :10002 --seal
 ````
 
 To run the **second** client:
 
 ````bash
-polygon-edge server --data-dir ./test-chain-2 --chain genesis.json --grpc :20000 --libp2p :20001 --jsonrpc :20002 --seal
+polygon-edge server --data-dir ./test-chain-2 --chain genesis.json --grpc-address :20000 --libp2p :20001 --jsonrpc :20002 --seal
 ````
 
 To run the **third** client:
 
 ````bash
-polygon-edge server --data-dir ./test-chain-3 --chain genesis.json --grpc :30000 --libp2p :30001 --jsonrpc :30002 --seal
+polygon-edge server --data-dir ./test-chain-3 --chain genesis.json --grpc-address :30000 --libp2p :30001 --jsonrpc :30002 --seal
 ````
 
 To run the **fourth** client:
 
 ````bash
-polygon-edge server --data-dir ./test-chain-4 --chain genesis.json --grpc :40000 --libp2p :40001 --jsonrpc :40002 --seal
+polygon-edge server --data-dir ./test-chain-4 --chain genesis.json --grpc-address :40000 --libp2p :40001 --jsonrpc :40002 --seal
 ````
 
 To briefly go over what has been done so far:
@@ -342,12 +342,12 @@ Currently, we only support `json` based configuration file, sample config file c
 A Non-validator will always sync the latest blocks received from the validator node, you can start a non-validator node by running the following command.
 
 ````bash 
-polygon-edge server --data-dir <directory_path> --chain <genesis_filename> --grpc <portNo> --libp2p <portNo> --jsonrpc <portNo>
+polygon-edge server --data-dir <directory_path> --chain <genesis_filename> --grpc-address <portNo> --libp2p <portNo> --jsonrpc <portNo>
 ````
 For example, you can add **fifth** Non-validator client by executing the following command :
 
 ````bash
-polygon-edge server --data-dir ./test-chain --chain genesis.json --grpc :50000 --libp2p :50001 --jsonrpc :50002 
+polygon-edge server --data-dir ./test-chain --chain genesis.json --grpc-address :50000 --libp2p :50001 --jsonrpc :50002 
 ````
 :::
 

--- a/docs/working-with-node/backup-restore.md
+++ b/docs/working-with-node/backup-restore.md
@@ -28,7 +28,7 @@ This section guides you through creating archive data of the blockchain in a run
 `backup` command fetches blocks from a running node by gRPC and generates an archive file. If `--from` and `--to` are not given in the command, this command will fetch blocks from genesis to latest.
 
 ```bash
-$ polygon-edge backup --grpc 127.0.0.1:9632 --out backup.dat [--from 0x0] [--to 0x100]
+$ polygon-edge backup --grpc-address 127.0.0.1:9632 --out backup.dat [--from 0x0] [--to 0x100]
 ```
 
 ### Restore


### PR DESCRIPTION
# Description

This PR updates the legacy `--grpc` flag to be `--grpc-address`