### PR TITLE
Update sendTransaction doc

### DIFF
--- a/docs/get-started/json-rpc-commands.mdx
+++ b/docs/get-started/json-rpc-commands.mdx
@@ -290,33 +290,6 @@ Creates new message call transaction or a contract creation for signed transacti
 curl  https://rpc.poa.psdk.io:8545 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"],"id":1}'
 ````
 
-### eth_sendTransaction
-
-Creates new message call transaction or a contract creation, if the data field contains code.
-
----
-
-<h4><i>Parameters:</i></h4>
-<b> Object </b> - The transaction object
-
-*  <b>from: DATA, 20 Bytes </b> - The address the transaction is send from.
-*  <b>to: DATA, 20 Bytes </b> - (optional when creating new contract) The address the transaction is directed to.
-*  <b>gas: QUANTITY </b> - (optional, default: 90000) Integer of the gas provided for the transaction execution. It will return unused gas.
-*  <b>gasPrice: QUANTITY </b> - (optional, default: To-Be-Determined) Integer of the gasPrice used for each paid gas
-*  <b>value: QUANTITY </b> - (optional) Integer of the value sent with this transaction
-*  <b>data: DATA </b> - The compiled code of a contract OR the hash of the invoked method signature and encoded parameters. For details see Ethereum Contract ABI
-*  <b>nonce: QUANTITY </b> - (optional) Integer of a nonce. This allows overwriting your pending transactions that use the same nonce.
-
-<h4><i>Returns:</i></h4>
-
-*  <b>DATA, 32 Bytes </b> - the transaction hash, or the zero hash if the transaction is not yet available.
-
-<h4><i>Example:</i></h4>
-
-````bash
-curl https://rpc.poa.psdk.io:8545 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155","to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567","gas": "0x76c0", "gasPrice": "0x9184e72a000", "value": "0x9184e72a", "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],"id":1}'
-````
-
 ### eth_getTransactionByHash
 
 Returns the information about a transaction requested by transaction hash.

--- a/docs/working-with-node/query-json-rpc.md
+++ b/docs/working-with-node/query-json-rpc.md
@@ -29,8 +29,8 @@ polygon-edge genesis --premine 0x1010101010101010101010101010101010101010:0x1231
 
 The balance can be either a `hex` or `uint256` value.
 
-:::warning Only premine accounts from which you have a private key!
-If you premine accounts and do not have a private key to access them, you premined balance will be locked
+:::warning Only premine accounts for which you have a private key!
+If you premine accounts and do not have a private key to access them, you premined balance will not be usable
 :::
 
 ## Step 2: Start the Polygon Edge in dev mode
@@ -68,7 +68,7 @@ const web3 = new Web3("<provider's websocket jsonrpc address>"); //example: ws:/
 web3.eth.accounts
   .signTransaction(
     {
-      to: "<recipient public address>",
+      to: "<recipient address>",
       value: web3.utils.toWei("<value in ETH>"),
       gas: 21000,
     },

--- a/docs/working-with-node/query-json-rpc.md
+++ b/docs/working-with-node/query-json-rpc.md
@@ -29,6 +29,10 @@ polygon-edge genesis --premine 0x1010101010101010101010101010101010101010:0x1231
 
 The balance can be either a `hex` or `uint256` value.
 
+:::warning Only premine accounts from which you have a private key!
+If you premine accounts and do not have a private key to access them, you premined balance will be locked
+:::
+
 ## Step 2: Start the Polygon Edge in dev mode
 
 To start the Polygon Edge in development mode, which is explained in the [CLI Commands](/docs/get-started/cli-commands) section, 
@@ -58,9 +62,22 @@ The command should return the following output:
 Now that we've confirmed the account we set up as premined has the correct balance, we can transfer some ether:
 
 ````bash
-polygon-edge txpool add --nonce 0 --from 0x1010101010101010101010101010101010101010 --to 0x0000000000000000000000000000000000000010 --value 0x100
+var Web3 = require("web3");
+
+const web3 = new Web3("<provider's websocket jsonrpc address>"); //example: ws://localhost:10002/ws
+web3.eth.accounts
+  .signTransaction(
+    {
+      to: "<recipient public address>",
+      value: web3.utils.toWei("<value in ETH>"),
+      gas: 21000,
+    },
+    "<private key from premined account>"
+  )
+  .then((signedTxData) => {
+    web3.eth
+      .sendSignedTransaction(signedTxData.rawTransaction)
+      .on("receipt", console.log);
+  });
+
 ````
-
-The **txpool add** command adds the transaction to the transaction pool.
-
-In this case, the transfer is from `0x1010101010101010101010101010101010101010` to `0x0000000000000000000000000000000000000010`, with the value being `0x100` wei.

--- a/docs/working-with-node/query-json-rpc.md
+++ b/docs/working-with-node/query-json-rpc.md
@@ -61,7 +61,7 @@ The command should return the following output:
 
 Now that we've confirmed the account we set up as premined has the correct balance, we can transfer some ether:
 
-````bash
+````js
 var Web3 = require("web3");
 
 const web3 = new Web3("<provider's websocket jsonrpc address>"); //example: ws://localhost:10002/ws


### PR DESCRIPTION
We have removed txpool add command because we do not support sending unsigned transactions. 
This PR adds JavaScript script which is used for sending signed tx, so that users can test their network